### PR TITLE
Add auth header

### DIFF
--- a/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
+++ b/src/components/pages/admin/PageProductImport/components/CSVFileImport.tsx
@@ -35,25 +35,29 @@ export default function CSVFileImport({url, title}: CSVFileImportProps) {
   };
 
   const uploadFile = async (e: any) => {
-      // Get the presigned URL
-      const response = await axios.get<SignedUrlResponse>(url,{
-        params: {
-          name: encodeURIComponent(file.name)
-        }
-      })
-      console.log('File to upload: ', file.name)
-      console.log('Uploading to: ', response.data)
-      const result = await fetch(response.data.url, {
-        headers: {
-          'Content-Type': 'text/csv'
-        },
-        method: 'PUT',
-        body: file
-      })
-      console.log('Result: ', result)
-      setFile('');
-    }
-  ;
+    const token = localStorage.getItem('authorization_token');
+    const headers = token != null ? {'Authorization': `${token}`} : null;
+
+    // Get the presigned URL
+    const response = await axios.get<SignedUrlResponse>(url,{
+      headers,
+      params: {
+        name: encodeURIComponent(file.name)
+      }
+    })
+    console.log('File to upload: ', file.name)
+    console.log('Uploading to: ', response.data)
+
+    const result = await fetch(response.data.url, {
+      headers: {
+        'Content-Type': 'text/csv',
+      },
+      method: 'PUT',
+      body: file
+    })
+    console.log('Result: ', result)
+    setFile('');
+  };
 
   return (
     <div className={classes.content}>

--- a/src/constants/apiPaths.ts
+++ b/src/constants/apiPaths.ts
@@ -2,7 +2,7 @@
 const API_PATHS = {
   products: 'https://ej9c12cgfl.execute-api.eu-west-1.amazonaws.com/dev/products',
   order: 'https://ej9c12cgfl.execute-api.eu-west-1.amazonaws.com/dev',
-  import: 'https://7a3g13gk41.execute-api.eu-west-1.amazonaws.com/dev/',
+  import: 'https://7a3g13gk41.execute-api.eu-west-1.amazonaws.com/dev',
   bff: 'https://ej9c12cgfl.execute-api.eu-west-1.amazonaws.com/dev'
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,8 +13,15 @@ axios.interceptors.response.use(
     return response;
   },
   function(error) {
-    if (error.response.status === 400) {
+    const status = error.response?.status;
+    if (status === 400) {
       alert(error.response.data?.data);
+    }
+    if (status === 401) {
+      alert("Unauthorized");
+    }
+    if (status === 403) {
+      alert("Access denied");
     }
     return Promise.reject(error.response);
   }


### PR DESCRIPTION
# Task 7 (Lambda Authorizer + Cognito Authorization)

## What was done
 - Updated client application to send Authorization: Basic authorization_token header on import. Client got authorization_token value from browser localStorage.
- Client application should display alerts for the responses in 401 and 403 HTTP statuses.

